### PR TITLE
Workaround for Windows build regression SM v102

### DIFF
--- a/.github/workflows/build-spidermonkey-action.yml
+++ b/.github/workflows/build-spidermonkey-action.yml
@@ -77,7 +77,9 @@ jobs:
         shell: bash
         working-directory: ${{ env.MOZJS_DIR }}/mozglue/misc
         run: |
-          sed '/"WindowsDllMain.cpp"/d' moz.build > moz.build
+          ls -al *.build
+          mv moz.build moz.build.org
+          sed '/"WindowsDllMain.cpp"/d' moz.build.org > moz.build
         
       - name: Preparing Spidermonkey build for Windows
         if: steps.cache-dir.outputs.cache-hit != 'true' && runner.os == 'Windows'

--- a/.github/workflows/build-spidermonkey-action.yml
+++ b/.github/workflows/build-spidermonkey-action.yml
@@ -100,8 +100,8 @@ jobs:
         shell: bash
         working-directory: ${{ env.MOZJS_DIR }}/js/src/build-opt
         #unlink python@3.10 because ./configure will fail when creating _virtualenv
+        #brew unlink python@3.10
         run: |
-          brew unlink python@3.10
           ../configure --enable-shared-js --disable-ctypes --disable-jit --disable-jemalloc --enable-optimize --enable-hardening --with-intl-api --build-backends=RecursiveMake --disable-debug --enable-gczeal
 
       - name: Build Spidermonkey

--- a/.github/workflows/build-spidermonkey-action.yml
+++ b/.github/workflows/build-spidermonkey-action.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         mozjs-version: [ 91, 102 ]
-        os: [ ubuntu-22.04, windows-2022, macos-12 ]
+        os: [ ubuntu-22.04, windows-2022, macos-11 ]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-spidermonkey-action.yml
+++ b/.github/workflows/build-spidermonkey-action.yml
@@ -13,12 +13,16 @@ jobs:
       fail-fast: false
       matrix:
         mozjs-version: [ 91, 102 ]
-        os: [ ubuntu-22.04, windows-2022, macos-11 ]
+        os: [ ubuntu-22.04, windows-2022, macos-12 ]
 
     steps:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
+      
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
 
       - name: Detect latest Spidermonkey version
         shell: bash

--- a/.github/workflows/build-spidermonkey-action.yml
+++ b/.github/workflows/build-spidermonkey-action.yml
@@ -72,6 +72,13 @@ jobs:
           chmod +x ./configure
           mkdir -p build-opt
 
+      - name: Preparing Spidermonkey build for Windows (SM v102) Pre-Step (https://bugzilla.mozilla.org/show_bug.cgi?id=1751561)
+        if: steps.cache-dir.outputs.cache-hit != 'true' && runner.os == 'Windows' && matrix.mozjs-version == '102'
+        shell: bash
+        working-directory: ${{ env.MOZJS_DIR }}/mozglue/misc
+        run: |
+          sed '/"WindowsDllMain.cpp"/d' moz.build > moz.build
+        
       - name: Preparing Spidermonkey build for Windows
         if: steps.cache-dir.outputs.cache-hit != 'true' && runner.os == 'Windows'
         shell: bash


### PR DESCRIPTION
SM v102 doesn't build successfully for Windows,
because of a duplicated WindowsDllMain function.

Workaround: Comment out file for compilation


See https://bugzilla.mozilla.org/show_bug.cgi?id=1751561