### PR TITLE
Update download URLs for Firefox ESR versions

### DIFF
--- a/get_sm.sh
+++ b/get_sm.sh
@@ -48,14 +48,14 @@ elif [ "$LTS" -eq 102 ]; then
   fi
 elif [ "$LTS" -eq 115 ]; then
   # EOL Spidermonkey versions
-  DOWNLOAD_URL="https://archive.mozilla.org/pub/firefox/releases/115.26.0esr/source/firefox-115.26.0esr.source.tar.xz"
+  DOWNLOAD_URL="https://archive.mozilla.org/pub/firefox/releases/115.29.0esr/source/firefox-115.29.0esr.source.tar.xz"
   # download old version from Mozilla archive server
   if [ "$DOWNLOAD" == "true" ]; then
     curl -s -L -O -J "$DOWNLOAD_URL"
   fi
 elif [ "$LTS" -eq 128 ]; then
   # EOL Spidermonkey versions
-  DOWNLOAD_URL="https://archive.mozilla.org/pub/firefox/releases/128.13.0esr/source/firefox-128.13.0esr.source.tar.xz"
+  DOWNLOAD_URL="https://archive.mozilla.org/pub/firefox/releases/128.14.0esr/source/firefox-128.14.0esr.source.tar.xz"
   # download old version from Mozilla archive server
   if [ "$DOWNLOAD" == "true" ]; then
     curl -s -L -O -J "$DOWNLOAD_URL"


### PR DESCRIPTION
Update to:

- 115.29.0esr
- 128.14.0esr